### PR TITLE
Change cache to a Map and expose it

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,29 @@ const store = new Vuex.Store({
   }
 })
 
-store.cacheDispatch('LIST')
+store.cache.dispatch('LIST')
 ```
 
 ### api
 
 ```javascript
-store.cacheDispatch(ACTION_NAME)
+store.cache.dispatch(ACTION_NAME)
 ```
 params is same with vuex store.dispatch
 
 cacheDispatch will cache the result, so do **not** use it to make some actions with different params, when params change, cacheDispatch would still return the first cached result, and the data in store will not change.
 
 ```javascript
-store.removeCache(ACTION_NAME)
+store.cache.delete(ACTION_NAME)
 ```
 remove cached action, will **not** remove the data in store. when call cacheDispatch with same type, the request in that action will run again.
 
 ```javascript
-store.hasCache(ACTION_NAME)
+store.cache.has(ACTION_NAME)
 ```
 return bool if ACTION\_NAME has been cached
 
 ```javascript
-store.clearCache()
+store.cache.clear()
 ```
 clear all cached keys

--- a/index.js
+++ b/index.js
@@ -1,34 +1,14 @@
 'use strict';
 
 var index = (function (store) {
-  var cache = Object.create(null);
-  store.cacheDispatch = function () {
-    var type = arguments.length <= 0 ? undefined : arguments[0];
-    if (type in cache) {
-      return cache[type];
-    }
-    cache[type] = store.dispatch.apply(store, arguments);
-    return cache[type];
-  };
+  store.cache = new Map();
 
-  store.removeCache = function () {
-    var type = arguments.length <= 0 ? undefined : arguments[0];
-    if (type in cache) {
-      delete cache[type];
-      return true;
+  store.cache.dispatch = function () {
+    var type = arguments[0];
+    if (!store.cache.has(type)) {
+      store.cache.set(type, store.dispatch.apply(store, arguments));
     }
-    return false;
-  };
-
-  store.hasCache = function (key) {
-    return key in cache;
-  };
-
-  store.clearCache = function () {
-    for (var key in cache) {
-      delete cache[key];
-    }
-    return true;
+    return store.cache.get(type);
   };
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,11 @@
-export default store => {
-  const cache = Object.create(null)
-  store.cacheDispatch = function cacheDispatch () {
+export default (store) => {
+  store.cache = new Map()
+
+  store.cache.dispatch = function () {
     const type = arguments[0]
-    if (type in cache) {
-      return cache[type]
+    if (!store.cache.has(type)) {
+      store.cache.set(type, store.dispatch.apply(store, arguments))
     }
-    cache[type] = store.dispatch.apply(store, arguments)
-    return cache[type]
-  }
-
-  store.removeCache = actionName => {
-    if (actionName in cache) {
-      delete cache[actionName]
-      return true
-    }
-    return false
-  }
-
-  store.hasCache = key => {
-    return key in cache
-  }
-
-  store.clearCache = () => {
-    for (const key in cache) {
-      delete cache[key]
-    }
-    return true
+    return store.cache.get(type)
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,10 +45,10 @@ describe('cache vuex action', () => {
 
   it('cache action', done => {
     const dispatchSpy = spyOn(store, 'dispatch').andCallThrough()
-    store.cacheDispatch('LIST', 1, 2)
+    store.cache.dispatch('LIST', 1, 2)
     expect(dispatchSpy).toHaveBeenCalledWith('LIST', 1, 2)
     expect(spy.calls.length).toBe(1)
-    store.cacheDispatch('LIST')
+    store.cache.dispatch('LIST')
     expect(spy.calls.length).toBe(1)
 
     Vue.nextTick(() => {
@@ -59,27 +59,27 @@ describe('cache vuex action', () => {
   })
 
   it('remove cache return true', () => {
-    store.cacheDispatch('LIST')
+    store.cache.dispatch('LIST')
     expect(spy.calls.length).toBe(1)
-    expect(store.removeCache('LIST')).toBe(true)
-    expect(store.removeCache('LIST')).toBe(false)
-    store.cacheDispatch('LIST')
+    expect(store.cache.delete('LIST')).toBe(true)
+    expect(store.cache.delete('LIST')).toBe(false)
+    store.cache.dispatch('LIST')
     expect(spy.calls.length).toBe(2)
-    store.cacheDispatch('LIST')
+    store.cache.dispatch('LIST')
     expect(spy.calls.length).toBe(2)
   })
 
   it('remove cache not exist, return false', () => {
-    expect(store.removeCache('NO_TYPE')).toBe(false)
+    expect(store.cache.delete('NO_TYPE')).toBe(false)
   })
 
   it('clear all cache', () => {
-    store.cacheDispatch('LIST')
-    store.cacheDispatch('NAME', 'abc')
-    expect(store.hasCache('LIST')).toBe(true)
-    expect(store.hasCache('NAME')).toBe(true)
-    store.clearCache()
-    expect(store.hasCache('LIST')).toBe(false)
-    expect(store.hasCache('NAME')).toBe(false)
+    store.cache.dispatch('LIST')
+    store.cache.dispatch('NAME', 'abc')
+    expect(store.cache.has('LIST')).toBe(true)
+    expect(store.cache.has('NAME')).toBe(true)
+    store.cache.clear()
+    expect(store.cache.has('LIST')).toBe(false)
+    expect(store.cache.has('NAME')).toBe(false)
   })
 })


### PR DESCRIPTION
After used `vuex-cache` code for a while I realize it's methods is very similar to `Map` methods and doing some researches I also confirmed that Maps are better than _pure objects_(`Object.create(null)`).

- [Objects and Maps compared - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared)
- [Performance comparison - JSPerf](https://jsperf.com/es6-map-vs-object-properties/2)

So I'd changed `cache` constant to a Map instance, added `dispatch` method and expose it. Now all Map methods and `dispatch` is available under `store.cache` namespace. Also I'd changed the unit tests and README.

In fact, now this lib is faster and smaller, and the only side effects is IE11- that needs Map polyfill to run properly.