### PR TITLE
Expose vuex-cache also as an action enchancer

### DIFF
--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import vuexCache from '../src'
+import vuexCache, { cacheAction } from '../src'
 
 Vue.use(Vuex)
 
@@ -56,6 +56,12 @@ describe('cache vuex action', () => {
       NAME({ commit }, name) {
         commit('NAME', name)
       },
+      ENHANCED_ACTION_TEST: cacheAction(context => {
+        context.cache.dispatch('LIST', 1, 2)
+        expect(listSpy.mock.calls).toHaveLength(1)
+        context.cache.dispatch('LIST')
+        expect(listSpy.mock.calls).toHaveLength(2)
+      }),
     },
   }
 
@@ -72,6 +78,17 @@ describe('cache vuex action', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
+  })
+
+  it('is bound to action context', done => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch')
+    store.dispatch('ENHANCED_ACTION_TEST')
+    expect(dispatchSpy).toHaveBeenCalledWith('ENHANCED_ACTION_TEST')
+
+    Vue.nextTick(() => {
+      expect(store.state.list).toEqual(result)
+      done()
+    })
   })
 
   it('cache action', done => {

--- a/src/index.js
+++ b/src/index.js
@@ -78,4 +78,13 @@ const resolveParams = args => {
   return cachePlugin(args)
 }
 
+// expose plugin as default
 export default resolveParams
+
+// expose action enhancer
+export function cacheAction(action) {
+  return function cacheEnhancedAction(context, payload) {
+    cachePlugin(context)
+    return action(context, payload)
+  }
+}


### PR DESCRIPTION
@superwf Regarding your feature request in vuex (vuejs/vuex#895), I came accross the same issue, to be able to use context.cache anywhere in my code.
However, the linked discussion (vuejs/vuex#571) ended up with using action enhancers:

> We're finally going in the way of action enhancers.

A nice feature for vuex-cache would be to expose the plugin *and* an action enhancer wrapper.

*API*
```js
// expose action enhancer
export function cacheAction(action) {
  return function cacheEnhancedAction(context, payload) {
    cachePlugin(context)
    return action(context, payload)
  }
}
```
To be used as:
```js
import { cacheAction } from 'vuex-cache'
actions: {
  CACHED_ACTION: cacheAction(({ cache }, payload) => {
    cache.dispatch('OTHER_ACTION', payload);
  });
}
```
What do you think ?