### PR TITLE
feat: partially clear the cache by action name

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ store.cache.delete('FETCH_REPOSITORY', 219);
 //=> false
 ```
 
+> Only exact matches are deleted. Use `store.cache.clear` to delete all items or by action name.
+
 ### `store.cache.clear`
 
 Clear the cache, delete all actions from it. Returns `true` if cache is cleared and `false` otherwise.
@@ -175,6 +177,15 @@ Clear the cache, delete all actions from it. Returns `true` if cache is cleared 
 ```js
 store.cache.clear();
 //=> true
+```
+
+If using the type parameter, only actions with the specified type are deleted from cache and the number of deleted keys is returned.
+
+```js
+// store.cache.dispatch('FETCH_REPOSITORIES', { page: 1 });
+// store.cache.dispatch('FETCH_REPOSITORIES', { page: 2 });
+store.cache.clear('FETCH_REPOSITORIES');
+//=> 2
 ```
 
 ### `mapCacheActions`

--- a/__test__/cache.clear.test.js
+++ b/__test__/cache.clear.test.js
@@ -27,20 +27,30 @@ describe('store.cache.clear', () => {
 
     expect(store.cache.has('A')).toBe(false)
     expect(store.cache.has('B', { name: '@superwf' })).toBe(false)
+  })
 
+  it('clear only specified action dispatches from cache', () => {
+    const store = createStore({
+      A: () => {},
+      B: () => {},
+      BC: () => {},
+    })
     store.cache.dispatch('A')
-    store.cache.dispatch('B', { name: '@superwf1' })
-    store.cache.dispatch('B', { name: '@superwf2' })
+    store.cache.dispatch('B', { page: 1 })
+    store.cache.dispatch('B', { page: 2 })
+    store.cache.dispatch('BC')
 
     expect(store.cache.has('A')).toBe(true)
-    expect(store.cache.has('B', { name: '@superwf1' })).toBe(true)
-    expect(store.cache.has('B', { name: '@superwf2' })).toBe(true)
+    expect(store.cache.has('B', { page: 1 })).toBe(true)
+    expect(store.cache.has('B', { page: 2 })).toBe(true)
+    expect(store.cache.has('BC')).toBe(true)
 
     const count = store.cache.clear('B')
 
     expect(count).toBe(2)
     expect(store.cache.has('A')).toBe(true)
-    expect(store.cache.has('B', { name: '@superwf1' })).toBe(false)
-    expect(store.cache.has('B', { name: '@superwf2' })).toBe(false)
+    expect(store.cache.has('B', { page: 1 })).toBe(false)
+    expect(store.cache.has('B', { page: 2 })).toBe(false)
+    expect(store.cache.has('BC')).toBe(true)
   })
 })

--- a/__test__/cache.clear.test.js
+++ b/__test__/cache.clear.test.js
@@ -36,19 +36,22 @@ describe('store.cache.clear', () => {
       BC: () => {},
     })
     store.cache.dispatch('A')
+    store.cache.dispatch('B')
     store.cache.dispatch('B', { page: 1 })
     store.cache.dispatch('B', { page: 2 })
     store.cache.dispatch('BC')
 
     expect(store.cache.has('A')).toBe(true)
+    expect(store.cache.has('B')).toBe(true)
     expect(store.cache.has('B', { page: 1 })).toBe(true)
     expect(store.cache.has('B', { page: 2 })).toBe(true)
     expect(store.cache.has('BC')).toBe(true)
 
     const count = store.cache.clear('B')
 
-    expect(count).toBe(2)
+    expect(count).toBe(3)
     expect(store.cache.has('A')).toBe(true)
+    expect(store.cache.has('B')).toBe(false)
     expect(store.cache.has('B', { page: 1 })).toBe(false)
     expect(store.cache.has('B', { page: 2 })).toBe(false)
     expect(store.cache.has('BC')).toBe(true)

--- a/__test__/cache.clear.test.js
+++ b/__test__/cache.clear.test.js
@@ -27,5 +27,20 @@ describe('store.cache.clear', () => {
 
     expect(store.cache.has('A')).toBe(false)
     expect(store.cache.has('B', { name: '@superwf' })).toBe(false)
+
+    store.cache.dispatch('A')
+    store.cache.dispatch('B', { name: '@superwf1' })
+    store.cache.dispatch('B', { name: '@superwf2' })
+
+    expect(store.cache.has('A')).toBe(true)
+    expect(store.cache.has('B', { name: '@superwf1' })).toBe(true)
+    expect(store.cache.has('B', { name: '@superwf2' })).toBe(true)
+
+    const count = store.cache.clear('B')
+
+    expect(count).toBe(2)
+    expect(store.cache.has('A')).toBe(true)
+    expect(store.cache.has('B', { name: '@superwf1' })).toBe(false)
+    expect(store.cache.has('B', { name: '@superwf2' })).toBe(false)
   })
 })

--- a/src/vuex-cache.js
+++ b/src/vuex-cache.js
@@ -172,7 +172,7 @@ const defineCache = (store, options) => {
       const [type] = resolveParams(params)
       if (type) {
         return Array.from(state.keys())
-          .filter((key) => key.startsWith(type))
+          .filter((key) => key.split(':')[0] === type)
           .reduce((count, key) => count + state.delete(key), 0)
       }
       return !!state.clear()

--- a/src/vuex-cache.js
+++ b/src/vuex-cache.js
@@ -164,14 +164,22 @@ const defineCache = (store, options) => {
 
     /**
      * Clear cache. Returns `true` if cache was cleared and `false` otherwise.
-     * @returns {boolean}
+     * If using the type parameter, only actions with the specified type are
+     * deleted from cache and the number of deleted keys is returned.
+     * @returns {boolean|number}
      */
-    clear() {
-      return state.clear()
+    clear(...params) {
+      const [type] = resolveParams(params)
+      if (type) {
+        return Array.from(state.keys())
+          .filter((key) => key.startsWith(type))
+          .reduce((count, key) => count + state.delete(key), 0)
+      }
+      return !!state.clear()
     },
 
     /**
-     * Detele an action dispatch from cache. Returns `true` if it was deleted
+     * Delete an action dispatch from cache. Returns `true` if it was deleted
      * and `false` otherwise.
      * @returns {boolean}
      */

--- a/types/vuex-cache.d.ts
+++ b/types/vuex-cache.d.ts
@@ -27,9 +27,13 @@ export interface StoreCache {
    * Clear cache. Returns `true` if cache was cleared and `false` otherwise.
    */
   clear(): boolean
+  /**
+   * Partially clear cache by type. Returns the number of deleted items.
+   */
+  clear(type: string): number
 
   /**
-   * Detele an action from cache. Returns `true` if it was deleted
+   * Delete an action from cache. Returns `true` if it was deleted
    * and `false` otherwise.
    */
   delete(type: string, payload?: any): boolean


### PR DESCRIPTION
This PR adds an optional parameter to the `store.cache.clear` method to partially clear the cache by action name (regardless of the payload).

_In opposite, the `store.cache.delete` method deletes one specific key (exact action name and payload)._ 

If the an action name is specified, the `number` of cleared keys is returned.
Otherwise, the `boolean` return type of the clear function is enforced (as `Map.clear` is `void` type).