### PR TITLE
Option to pass in cache key generator fn or value

### DIFF
--- a/src/vuex-cache.js
+++ b/src/vuex-cache.js
@@ -48,13 +48,19 @@ const GenerateKeyError = new Error("Can't generate key from parameters.")
  * @param {DispatchParams} params
  * @returns {string|Error}
  */
-const generateKey = (params) => {
+const defaultGenerateKey = function (params) {
   try {
-    const [type, payload] = resolveParams(params)
-    return `${type}:${toString(payload)}`
+    const ref = resolveParams(params)
+    const type = ref[0]
+    const payload = ref[1]
+    return (type + ':' + (toString(payload)))
   } catch (_) {
     return GenerateKeyError
   }
+}
+
+const configurableGlobal = {
+  generateKey: defaultGenerateKey
 }
 
 /**
@@ -110,6 +116,9 @@ const state = new Map()
  * @param {Options} [options]
  */
 const defineCache = (store, options) => {
+  if (options && options.generateKey) {
+    configurableGlobal.generateKey = options.generateKey
+  }
   const cache = {
     /**
      * Dispatch an action and set it on cache.
@@ -117,7 +126,7 @@ const defineCache = (store, options) => {
      * @returns {Promise<any>}
      */
     dispatch(...params) {
-      const key = generateKey(params)
+      const key = configurableGlobal.generateKey(params)
 
       if (key === GenerateKeyError) {
         // Fallback on generateKey errors.
@@ -151,7 +160,7 @@ const defineCache = (store, options) => {
      * @returns {boolean}
      */
     has(...params) {
-      const key = generateKey(params)
+      const key = configurableGlobal.generateKey(params)
 
       if (key === GenerateKeyError) {
         // Fallback on generateKey errors.
@@ -184,7 +193,7 @@ const defineCache = (store, options) => {
      * @returns {boolean}
      */
     delete(...params) {
-      const key = generateKey(params)
+      const key = configurableGlobal.generateKey(params)
 
       if (key === GenerateKeyError) {
         // Fallback on generateKey errors.


### PR DESCRIPTION
!! I had to copy-paste the code changes manually, network restrictions applied.. please change it in case it seems necessary !!

This addition makes it possible to configure external cache key generator function, globally or per-call. 
See readme.md for examples.
